### PR TITLE
Add new business steps to hyperrealistic example

### DIFF
--- a/examples/hyperrealistic-order-processing.yaml
+++ b/examples/hyperrealistic-order-processing.yaml
@@ -90,6 +90,16 @@ do:
                   customerId: ${ $context.order.customer.id }
               output:
                 as: .customerInfo
+          - validateShippingAddress:
+              call: openapi
+              with:
+                document:
+                  endpoint: https://address.example.com/openapi.yaml
+                operationId: verifyAddress
+                parameters:
+                  address: ${ $context.order.shippingAddress }
+              output:
+                as: .validatedAddress
           - applyCoupons:
               call: http
               with:
@@ -563,6 +573,15 @@ do:
                       parameters:
                         campaignId: 42
                         orderId: ${ $context.order.id }
+                - updateCustomerSegmentation:
+                    call: openapi
+                    with:
+                      document:
+                        endpoint: https://marketing.example.com/openapi.yaml
+                      operationId: updateSegment
+                      parameters:
+                        customerId: ${ $context.order.customer.id }
+                        segment: ${ $context.loyaltyStatus }
         - orchestrateProcurement:
             call: grpc
             with:


### PR DESCRIPTION
## Summary
- add shipping address validation in order preprocessing
- update marketing segmentation in final enterprise processes

## Testing
- `python3 - <<'PY'
import yaml, sys
path='examples/hyperrealistic-order-processing.yaml'
try:
    with open(path) as f:
        yaml.safe_load(f)
    print('YAML OK')
except Exception as e:
    print('YAML Error:', e)
    sys.exit(1)
PY`


------
https://chatgpt.com/codex/tasks/task_e_684e21d99794832481d5f8d9e4164687